### PR TITLE
Add useNormalCircle and lineColor options

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ var layer = L.TileLayer.maskCanvas({
        radius: 5,  // radius in pixels or in meters (see useAbsoluteRadius)
        useAbsoluteRadius: true,  // true: r in meters, false: r in pixels
        color: '#000',  // the color of the layer
-       opacity: 0.5,  // opacity of the not coverted area
+       opacity: 0.5,  // opacity of the not covered area
+       useNormalCircle: false,  // true results in normal circles, not masked circles
+       lineColor: '#A00'   // color of the circle outline if useNormalCircle is true
+
 });
 ```
 

--- a/src/L.TileLayer.MaskCanvas.js
+++ b/src/L.TileLayer.MaskCanvas.js
@@ -4,6 +4,7 @@ L.TileLayer.MaskCanvas = L.TileLayer.Canvas.extend({
         useAbsoluteRadius: true,  // true: radius in meters, false: radius in pixels
         color: '#000',
         opacity: 0.5,
+        useNormalCircle: false,
         debug: false
     },
 
@@ -87,15 +88,24 @@ L.TileLayer.MaskCanvas = L.TileLayer.Canvas.extend({
             self = this,
             p,
             tileSize = this.options.tileSize;
-        g.globalCompositeOperation = 'source-over';
         g.fillStyle = this.options.color;
-        g.fillRect(0, 0, tileSize, tileSize);
-        g.globalCompositeOperation = 'destination-out';
+        if (this.options.lineColor) {
+          g.strokeStyle = this.options.lineColor;
+          g.lineWidth = this.options.lineWidth || 1;
+        }
+        g.globalCompositeOperation = 'source-over';
+        if (!this.options.useNormalCircle) {
+            g.fillRect(0, 0, tileSize, tileSize);
+            g.globalCompositeOperation = 'destination-out';
+        }
         coordinates.forEach(function(coords) {
             p = self._tilePoint(ctx, coords);
             g.beginPath();
             g.arc(p[0], p[1], self._getRadius(), 0, Math.PI * 2);
             g.fill();
+            if (self.options.lineColor) {
+                g.stroke();
+            }
         });
     },
 


### PR DESCRIPTION
I needed a lightweight layer to show small circles for a bunch of points. It seemed like maskcanvas was exactly what I needed, except without the mask. So I added a couple of options to maskcanvas and was happy with the result. Merge my changes in if you think they would be beneficial to others. Also, feel free to change the new option names if you prefer something else.

Thanks,
Mark
