### PR TITLE
Fix versioned _createTile

### DIFF
--- a/src/L.TileLayer.MaskCanvas.js
+++ b/src/L.TileLayer.MaskCanvas.js
@@ -27,26 +27,6 @@ L.TileLayer.MaskCanvas = L.TileLayer.Canvas.extend({
         };
     },
 
-    // return >0 if v1 > v2, <0 if v1 < v2, 0 if v1 == v2
-    _versionCompare: function (v1, v2) {
-        var va1 = v1.split(".");
-        var va2 = v2.split(".");
-
-        var limit = Math.min (va1.length, va2.length);
-        var result = 0;
-        for (var n = 0; (n < limit) && (result == 0); n++) {
-            result = (+va1[n]) - (+va2[n]);
-            if (isNaN(result)) {
-                return undefined;
-            }
-        }
-
-        if (result == 0) {
-            result = va1.length - va2.length;
-        }
-        return result;
-    },
-
     _drawDebugInfo: function (ctx) {
         var max = this.tileSize;
         var g = ctx.canvas.getContext('2d');
@@ -209,11 +189,9 @@ L.TileLayer.MaskCanvas = L.TileLayer.Canvas.extend({
     }
 });
 
-L.TileLayer.maskCanvas = function (options) {
+L.TileLayer.maskCanvas = function(options) {
     var mc = new L.TileLayer.MaskCanvas(options);
-    var vcomp = mc._versionCompare("0.7", L.version);
-    if (vcomp !== undefined && vcomp < 0) {
-        mc._createTile = mc._oldCreateTile;
-    }
+    leafletVersion = parseInt(L.version.match(/\d{1,}\.(\d{1,})\.\d{1,}/)[1], 10);
+    if (leafletVersion < 7) mc._createTile = mc._oldCreateTile;
     return mc;
 };


### PR DESCRIPTION
Previously, even if leaflet version was > 7, it was still using _oldCreateTile, which is incorrect.
