### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Leaflet MaskCanvas
+# Leaflet MaskCanvas
 
 A leaflet canvas layer for displaying large coverage data sets.
 
@@ -12,7 +12,7 @@ __Features__:
 
 Check out the demo at http://domoritz.github.com/vbb-coverage/.
 
-##Usage
+## Usage
 
 ### Set up
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
